### PR TITLE
ci: add Discord action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,3 +17,33 @@ jobs:
           build_prereleases: true
           ssh_key: ${{ secrets.DEPLOY_KEY }}
           composer_dir: src/usr/local/php/unraid-tailscale-utils/
+
+      - name: Actions for Discord (Release)
+        uses: Ilshidur/action-discord@0.4.0
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.TAILSCALE_DISCORD_WEBHOOK }}
+        with:
+          args: |
+            🚀 **Tailscale Release ${{ inputs.version }}**
+
+            View Release: https://github.com/${{ github.repository }}/releases/tag/${{ inputs.version }}
+
+            **Changelog:**
+
+            ${{ github.event.release.body }}
+        if: github.event.release.prerelease == false
+
+      - name: Actions for Discord (Preview)
+        uses: Ilshidur/action-discord@0.4.0
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.TAILSCALE_DISCORD_WEBHOOK }}
+        with:
+          args: |
+            🚀 **Tailscale Preview ${{ inputs.version }}**
+
+            View Release: https://github.com/${{ github.repository }}/releases/tag/${{ inputs.version }}
+
+            **Changelog:**
+
+            ${{ github.event.release.body }}
+        if: github.event.release.prerelease == true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,14 +19,14 @@ jobs:
           composer_dir: src/usr/local/php/unraid-tailscale-utils/
 
       - name: Actions for Discord (Release)
-        uses: Ilshidur/action-discord@0.4.0
+        uses: Ilshidur/action-discord@d2594079a10f1d6739ee50a2471f0ca57418b554
         env:
           DISCORD_WEBHOOK: ${{ secrets.TAILSCALE_DISCORD_WEBHOOK }}
         with:
           args: |
-            🚀 **Tailscale Release ${{ inputs.version }}**
+            🚀 **Tailscale Release ${{ github.event.release.name }}**
 
-            View Release: https://github.com/${{ github.repository }}/releases/tag/${{ inputs.version }}
+            View Release: ${{ github.event.release.html_url }}
 
             **Changelog:**
 
@@ -34,14 +34,14 @@ jobs:
         if: github.event.release.prerelease == false
 
       - name: Actions for Discord (Preview)
-        uses: Ilshidur/action-discord@0.4.0
+        uses: Ilshidur/action-discord@d2594079a10f1d6739ee50a2471f0ca57418b554
         env:
           DISCORD_WEBHOOK: ${{ secrets.TAILSCALE_DISCORD_WEBHOOK }}
         with:
           args: |
-            🚀 **Tailscale Preview ${{ inputs.version }}**
+            🚀 **Tailscale Preview ${{ github.event.release.name }}**
 
-            View Release: https://github.com/${{ github.repository }}/releases/tag/${{ inputs.version }}
+            View Release: ${{ github.event.release.html_url }}
 
             **Changelog:**
 


### PR DESCRIPTION
- Eli disqualified for breaking CONTRIBUTING rules in unraid/api

Signed-off-by: Derek Kaser <11674153+dkaser@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated Discord notifications to the release workflow for stable and preview releases. Notifications use release metadata to post a titled message with a “View Release” link and the changelog, trigger appropriately for prerelease vs stable, and run as part of the release process to keep followers informed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->