### PR TITLE
ci: strip conventional commit prefixes in release body

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -23,3 +23,6 @@ exclude-labels:
   - "ci"
   - "perf"
   - "refactor"
+replacers:
+  - search: '/^(feat|fix|chore|refactor)(\(.+\))?: /'
+    replace: ""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation to produce cleaner, user-friendly release notes by removing conventional-commit prefixes (e.g., feat:, fix:, chore:, refactor:, with optional scopes) from PR titles.
  * This change streamlines how changes are presented in future releases, making entries easier to scan and understand.
  * No impact on product functionality; affects release notes formatting only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->