### PR TITLE
ci: different color for preview notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           avatarUrl: https://raw.githubusercontent.com/unraid/unraid-tailscale/trunk/logo.png
           thumbnailUrl: https://raw.githubusercontent.com/unraid/unraid-tailscale/trunk/logo.png
           severity: info
-          color: "#00ff00"
+          color: ${{ toJson(github.event.release.prerelease && '#ffff00' || '#00ff00') }}
           title: New Update Available
           description: |
             ## :loudspeaker: Tailscale Plugin Update : ${{ github.event.release.name }}
@@ -59,5 +59,5 @@ jobs:
             [
               {"name": "Channel", "value": ${{ toJson(github.event.release.prerelease && ':test_tube: Preview' || 'Release') }}, "inline": true},
               {"name": ":label: Tag", "value": ${{ toJson(github.event.release.tag_name) }}, "inline": true},
-              {"name": ":link: Release Link", "value": ${{ toJson(github.event.release.html_url) }} }
+              {"name": ":link: Github Release", "value": "[Link](${{ github.event.release.html_url }})" }
             ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,5 +59,5 @@ jobs:
             [
               {"name": ":tv: Channel", "value": ${{ toJson(github.event.release.prerelease && 'Preview :test_tube:' || 'Release') }}, "inline": true},
               {"name": ":label: Tag", "value": ${{ toJson(github.event.release.tag_name) }}, "inline": true},
-              {"name": ":link: Github Release", "value": ${{ toJson(format("[Link]({0})", github.event.release.html_url)) }}, "inline": true}
+              {"name": ":link: Github Release", "value": ${{ toJson(format('[Link]({0})', github.event.release.html_url)) }}, "inline": true}
             ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           avatarUrl: https://raw.githubusercontent.com/unraid/unraid-tailscale/trunk/logo.png
           thumbnailUrl: https://raw.githubusercontent.com/unraid/unraid-tailscale/trunk/logo.png
           severity: info
-          color: ${{ toJson(github.event.release.prerelease && '#ffff00' || '#00ff00') }}
+          color: ${{ github.event.release.prerelease && '#ffff00' || '#00ff00' }}
           title: New Update Available
           description: |
             ## :loudspeaker: Tailscale Plugin Update : ${{ github.event.release.name }}
@@ -57,7 +57,7 @@ jobs:
             ${{ github.event.release.body }}
           fields: |
             [
-              {"name": "Channel", "value": ${{ toJson(github.event.release.prerelease && ':test_tube: Preview' || 'Release') }}, "inline": true},
+              {"name": ":tv: Channel", "value": ${{ toJson(github.event.release.prerelease && 'Preview :test_tube:' || 'Release') }}, "inline": true},
               {"name": ":label: Tag", "value": ${{ toJson(github.event.release.tag_name) }}, "inline": true},
-              {"name": ":link: Github Release", "value": "[Link](${{ github.event.release.html_url }})" }
+              {"name": ":link: Github Release", "value": ${{ toJson(format("[Link]({0})", github.event.release.html_url)) }}, "inline": true}
             ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Discord release notifications now use dynamic colors: yellow for prereleases and green for full releases, improving at-a-glance status.
  * Channel label and preview wording updated for clearer, friendlier display in notifications.
  * Release link label changed to “:link: Github Release” and now appears as a clickable Markdown link for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->