### PR TITLE
feat: configure peer relay port via GUI

### DIFF
--- a/src/usr/local/emhttp/plugins/tailscale/include/Pages/Tailscale.php
+++ b/src/usr/local/emhttp/plugins/tailscale/include/Pages/Tailscale.php
@@ -121,6 +121,12 @@ async function addTailscaleRoute() {
     var res = await $.post('/plugins/tailscale/include/data/Config.php',{action: 'add-route', route: $('#tailscaleRoute').val()});
     showTailscaleConfig();
 }
+async function setTailscaleRelayPort() {
+    $('div.spinner.fixed').show('fast');
+    tailscaleControlsDisabled(true);
+    var res = await $.post('/plugins/tailscale/include/data/Config.php',{action: 'set-relay-port', port: $('#tailscaleRelayPort').val()});
+    showTailscaleConfig();
+}
 function isValidCIDR(ip) {
     if (ip === undefined) {
         return false;

--- a/src/usr/local/emhttp/plugins/tailscale/include/data/Config.php
+++ b/src/usr/local/emhttp/plugins/tailscale/include/data/Config.php
@@ -99,6 +99,9 @@ try {
                 }
                 $exitSelect .= "</select>";
 
+                $relayPort        = $tailscaleInfo->getRelayServerPort() ?: "";
+                $relayPortWarning = $relayPort !== "" && ! $tailscaleInfo->isApprovedPeerRelay() ? $tr->tr("warnings.peer_relay_no_acl") : "&nbsp;";
+
                 $configRows = <<<EOT
                     <tr><td>{$tr->tr("info.accept_routes")}</td><td>{$tailscaleConInfo->AcceptRoutes}</td><td style="text-align: right;">{$acceptRoutesButton}</td></tr>
                     <tr><td>{$tr->tr("info.accept_dns")}</td><td>{$tailscaleConInfo->AcceptDNS}</td><td style="text-align: right;">{$acceptDNSButton}</td></tr>
@@ -106,6 +109,14 @@ try {
                     <tr><td>{$tr->tr("info.advertise_exit_node")}</td><td>{$tailscaleConInfo->AdvertiseExitNode}</td><td style="text-align: right;">{$advertiseExitButton}</td></tr>
                     <tr><td>{$tr->tr("info.use_exit_node")}</td><td>&nbsp;</td><td style="text-align: right;">{$exitSelect}</td></tr>
                     <tr><td>{$tr->tr("info.exit_node_local")}</td><td>{$tailscaleConInfo->ExitNodeLocal}</td><td style="text-align: right;">{$exitLocalButton}</td></tr>
+                    <tr>
+                        <td>{$tr->tr("info.peer_relay")}</td>
+                        <td><strong>{$relayPortWarning}</strong></td>
+                        <td style="text-align: right;">
+                            <input id='tailscaleRelayPort' class="narrow" type='number' min='0' max='65535' value='{$relayPort}' placeholder='Disabled' oninput='$("#tailscaleRelaySave").prop("disabled", false)'>
+                            <input id='tailscaleRelaySave' disabled type='button'value='{$tr->tr("save")}' onclick='setTailscaleRelayPort()'>
+                        </td>
+                    </tr>
 
                     EOT;
 
@@ -332,6 +343,28 @@ try {
 
             $utils->logmsg("Object: " . json_encode($serveConfig->getConfig(), JSON_UNESCAPED_SLASHES));
             $localAPI->setServeConfig($serveConfig);
+            break;
+        case 'set-relay-port':
+            if ( ! isset($_POST['port'])) {
+                throw new \Exception("Missing port parameter");
+            }
+
+            $port = null;
+
+            if ($_POST['port'] === '') {
+                $port = null;
+            } elseif (ctype_digit($_POST['port'])) {
+                $port = intval($_POST['port']);
+                if (($port < 0) || ($port > 65535)) {
+                    throw new \Exception("Port out of range: {$_POST['port']}");
+                }
+            } else {
+                throw new \Exception("Invalid port: {$_POST['port']}");
+            }
+
+            $utils->logmsg("Setting relay server port to: {$port}");
+
+            $localAPI->patchPref("RelayServerPort", $port);
             break;
     }
 } catch (\Throwable $e) {

--- a/src/usr/local/emhttp/plugins/tailscale/locales/en_US.json
+++ b/src/usr/local/emhttp/plugins/tailscale/locales/en_US.json
@@ -28,6 +28,7 @@
     "tailscale_disabled": "Tailscale is currently disabled. It can be enabled via the Settings tab.",
     "tailscale_lock": "Tailscale Lock",
     "warning": "Warning",
+    "save": "Save",
     "settings": {
         "basic": "Basic View",
         "advanced": "Advanced View",
@@ -87,6 +88,7 @@
         "connected_via": "Connected via Tailscale",
         "funnel_port": "Funnel Port for WebGUI",
         "port_in_use": "Port in Use",
+        "peer_relay": "Peer Relay Port",
         "lock": {
             "node_key": "Node Key",
             "public_key": "Public Key",
@@ -102,7 +104,8 @@
         "subnet": "Accepting Tailscale subnets on your Unraid server can disrupt local network connectivity in certain network configurations. Accepting routes is not required for your Unraid server to function as a subnet router or exit node. Only enable this option if your Unraid server needs to connect to remote subnets advertised by other devices.",
         "dns": "Enabling Tailscale MagicDNS on your server can disrupt name resolution inside Docker containers, potentially causing connectivity issues for applications. MagicDNS does not need to be enabled on the server for you to access your Unraid server using MagicDNS names (e.g., 'unraid.tailnet.ts.net') from other devices. Enabling 'Add Peers to /etc/hosts' is a safer alternative that allows Tailscale names to be used on the server.",
         "caution": "Proceed with caution and ensure you understand the implications of this change before continuing.",
-        "more_info": "For more information:"
+        "more_info": "For more information:",
+        "peer_relay_no_acl": "Not configured in Tailnet policy (access controls)."
     },
     "lock": {
         "sign": "Sign Nodes",

--- a/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/Info.php
+++ b/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/Info.php
@@ -478,7 +478,7 @@ class Info
 
         // Parse the packet filter rules to see if peer relay is approved
         // TODO: Get a better way to do this from Tailscale
-        foreach ($netmapRules as $key => $rule) {
+        foreach ($netmapRules as $rule) {
             if (isset($rule->CapGrant) && is_array($rule->CapGrant)) {
                 foreach ($rule->CapGrant as $capGrant) {
                     if (is_object($capGrant) && isset($capGrant->CapMap) && is_object($capGrant->CapMap) && isset($capGrant->CapMap->{'tailscale.com/cap/relay'})) {

--- a/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/Info.php
+++ b/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/Info.php
@@ -471,4 +471,31 @@ class Info
 
         return $this->status->Self->DNSName;
     }
+
+    public function isApprovedPeerRelay(): bool
+    {
+        $netmapRules = (array) $this->localAPI->getPacketFilterRules();
+
+        // Parse the packet filter rules to see if peer relay is approved
+        // TODO: Get a better way to do this from Tailscale
+        foreach ($netmapRules as $key => $rule) {
+            if (isset($rule->CapGrant) && is_array($rule->CapGrant)) {
+                foreach ($rule->CapGrant as $capGrant) {
+                    if (is_object($capGrant) && isset($capGrant->CapMap) && is_object($capGrant->CapMap) && isset($capGrant->CapMap->{'tailscale.com/cap/relay'})) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public function getRelayServerPort(): int|false
+    {
+        if (isset($this->prefs->RelayServerPort) && is_int($this->prefs->RelayServerPort)) {
+            return $this->prefs->RelayServerPort;
+        }
+        return false;
+    }
 }

--- a/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/LocalAPI.php
+++ b/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/LocalAPI.php
@@ -101,6 +101,11 @@ class LocalAPI
         return (object) json_decode($this->tailscaleLocalAPI('v0/serve-config'));
     }
 
+    public function getPacketFilterRules(): \stdClass
+    {
+        return (object) json_decode($this->tailscaleLocalAPI('v0/debug-packet-filter-rules'));
+    }
+
     public function resetServeConfig(): void
     {
         $this->tailscaleLocalAPI("v0/serve-config", APIMethods::POST, new \stdClass());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Relay port configuration UI for peers with numeric input (0–65535), save button and dynamic warning when ACL approval is absent
  * Async save action for relay port with input validation and persistent preference storage
  * New backend support to get/set relay port and surface errors on invalid input
  * New localization strings for relay controls and messaging
* **Enhancements**
  * Added checks for peer-relay approval and packet-filter rule inspection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->