### PR TITLE
chore: bump supported version to 7.1

### DIFF
--- a/plugin/plugin.j2
+++ b/plugin/plugin.j2
@@ -30,6 +30,19 @@ For older releases, see https://github.com/{{ env['GITHUB_REPOSITORY'] }}/releas
 ]]>
 </CHANGES>
 
+<FILE Run="/bin/bash" max="7.0.99">
+<INLINE>
+<![CDATA[
+echo "Installing the latest version of {{ name }} requires Unraid 7.1 or later."
+echo "Now installing the last compatible version..."
+
+plugin install https://raw.githubusercontent.com/{{ env['GITHUB_REPOSITORY'] }}/refs/tags/unraid-7.0/plugin/{{ name }}{{ env['PLUGIN_RELEASE'] }}.plg
+
+exit 1
+]]>
+</INLINE>
+</FILE>
+
 <FILE Name="/boot/config/plugins/{{ name }}/{{ tailscaleVersion }}.tgz">
 <URL>https://pkgs.tailscale.com/stable/{{ tailscaleVersion }}.tgz</URL>
 <SHA256>{{ tailscaleSHA256 }}</SHA256>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced compatibility for older Unraid versions by automatically detecting the environment and installing the last compatible plugin version, with clear messaging to guide users through the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->