### PR TITLE
feat: add configuration option for auto update

### DIFF
--- a/src/usr/local/emhttp/plugins/tailscale/include/Pages/Tailscale.php
+++ b/src/usr/local/emhttp/plugins/tailscale/include/Pages/Tailscale.php
@@ -81,6 +81,12 @@ async function setFeature(feature, enable) {
     var res = await $.post('/plugins/tailscale/include/data/Config.php',{action: 'set-feature', feature: feature, enable: enable});
     showTailscaleConfig();
 }
+async function setAutoUpdate(enable) {
+    $('div.spinner.fixed').show('fast');
+    tailscaleControlsDisabled(true);
+    var res = await $.post('/plugins/tailscale/include/data/Config.php',{action: 'set-auto-update', enable: enable});
+    showTailscaleConfig();
+}
 async function setAdvertiseExitNode(enable) {
     $('div.spinner.fixed').show('fast');
     tailscaleControlsDisabled(true);

--- a/src/usr/local/emhttp/plugins/tailscale/include/data/Config.php
+++ b/src/usr/local/emhttp/plugins/tailscale/include/data/Config.php
@@ -70,6 +70,10 @@ try {
                     "<input type='button' value='{$tr->tr("disable")}' onclick='setFeature(\"ssh\", false)'>" :
                     "<input type='button' value='{$tr->tr("enable")}' onclick='setFeature(\"ssh\", true)'>";
 
+                $autoUpdateButton = $tailscaleInfo->autoUpdateEnabled() ?
+                    "<input type='button' value='{$tr->tr("disable")}' onclick='setAutoUpdate(false)'>" :
+                    "<input type='button' value='{$tr->tr("enable")}' onclick='setAutoUpdate(true)'>";
+
                 $advertiseExitButton = $tailscaleInfo->usesExitNode() ? "<input type='button' value='{$tr->tr("enable")}' disabled>" :
                     (
                         $tailscaleInfo->advertisesExitNode() ?
@@ -103,6 +107,7 @@ try {
                 $relayPortWarning = $relayPort !== "" && ! $tailscaleInfo->isApprovedPeerRelay() ? $tr->tr("warnings.peer_relay_no_acl") : "&nbsp;";
 
                 $configRows = <<<EOT
+                    <tr><td>{$tr->tr("info.auto_update")}</td><td>{$tailscaleConInfo->AutoUpdate}</td><td style="text-align: right;">{$autoUpdateButton}</td></tr>
                     <tr><td>{$tr->tr("info.accept_routes")}</td><td>{$tailscaleConInfo->AcceptRoutes}</td><td style="text-align: right;">{$acceptRoutesButton}</td></tr>
                     <tr><td>{$tr->tr("info.accept_dns")}</td><td>{$tailscaleConInfo->AcceptDNS}</td><td style="text-align: right;">{$acceptDNSButton}</td></tr>
                     <tr><td>{$tr->tr("info.run_ssh")}</td><td>{$tailscaleConInfo->RunSSH}</td><td style="text-align: right;">{$sshButton}</td></tr>
@@ -303,6 +308,16 @@ try {
             }
             $utils->logmsg("Expiring node key");
             $localAPI->expireKey();
+            break;
+        case 'set-auto-update':
+            if ( ! isset($_POST['enable'])) {
+                throw new \Exception("Missing enable parameter");
+            }
+
+            $enable = filter_var($_POST['enable'], FILTER_VALIDATE_BOOLEAN);
+            $utils->logmsg("Setting auto update to " . ($enable ? "true" : "false"));
+
+            $localAPI->setAutoUpdate($enable);
             break;
         case 'exit-node':
             if ( ! isset($_POST['node'])) {

--- a/src/usr/local/emhttp/plugins/tailscale/locales/en_US.json
+++ b/src/usr/local/emhttp/plugins/tailscale/locales/en_US.json
@@ -89,6 +89,7 @@
         "funnel_port": "Funnel Port for WebGUI",
         "port_in_use": "Port in Use",
         "peer_relay": "Peer Relay Port",
+        "auto_update": "Auto Update",
         "lock": {
             "node_key": "Node Key",
             "public_key": "Public Key",

--- a/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/ConnectionInfo.php
+++ b/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/ConnectionInfo.php
@@ -32,4 +32,5 @@ class ConnectionInfo
     public string $ExitNodeLocal     = "";
     public string $AdvertiseExitNode = "";
     public string $UseExitNode       = "";
+    public string $AutoUpdate        = "";
 }

--- a/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/Info.php
+++ b/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/Info.php
@@ -116,6 +116,7 @@ class Info
         $info->RunSSH           = isset($prefs->RunSSH) ? ($prefs->RunSSH ? $this->tr("yes") : $this->tr("no")) : $this->tr("unknown");
         $info->ExitNodeLocal    = isset($prefs->ExitNodeAllowLANAccess) ? ($prefs->ExitNodeAllowLANAccess ? $this->tr("yes") : $this->tr("no")) : $this->tr("unknown");
         $info->UseExitNode      = $this->usesExitNode() ? $this->tr("yes") : $this->tr("no");
+        $info->AutoUpdate       = $this->autoUpdateEnabled() ? $this->tr("yes") : $this->tr("no");
 
         if ($this->advertisesExitNode()) {
             if ($this->status->Self->ExitNodeOption) {
@@ -497,5 +498,10 @@ class Info
             return $this->prefs->RelayServerPort;
         }
         return false;
+    }
+
+    public function autoUpdateEnabled(): bool
+    {
+        return $this->prefs->AutoUpdate->Apply ?? false;
     }
 }

--- a/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/LocalAPI.php
+++ b/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/LocalAPI.php
@@ -140,4 +140,13 @@ class LocalAPI
     {
         $this->tailscaleLocalAPI('v0/set-expiry-sooner?expiry=0', APIMethods::POST);
     }
+
+    public function setAutoUpdate(bool $enabled): void
+    {
+        $body                  = [];
+        $body["AutoUpdate"]    = ["Apply" => $enabled, "Check" => $enabled];
+        $body["AutoUpdateSet"] = ["ApplySet" => true, "CheckSet" => true];
+
+        $this->tailscaleLocalAPI("v0/prefs", APIMethods::PATCH, (object) $body);
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added auto-update configuration option to the Tailscale plugin interface, enabling users to toggle automatic updates on or off. The setting is persisted and managed through the plugin's configuration system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->