### PR TITLE
feat: add option to allow TPM encryption

### DIFF
--- a/src/usr/local/emhttp/plugins/tailscale/include/Pages/Settings.php
+++ b/src/usr/local/emhttp/plugins/tailscale/include/Pages/Settings.php
@@ -101,6 +101,19 @@ if ($tailscaleConfig->Enable) {
         </dd>
     </dl>
     <blockquote class='inline_help'><?= $tr->tr("settings.context.ip_forward"); ?></blockquote>
+
+    <dl>
+    <dt><?= $tr->tr("settings.tpm"); ?></dt>
+    <dd>
+        <select name='USE_TPM' id='USE_TPM' onchange='showSettingWarning("tpm","#USE_TPM");' size='1' class='narrow'>
+            <?= Utils::make_option( ! $tailscaleConfig->UseTPM, '0', $tr->tr("no"));?>
+            <?= Utils::make_option($tailscaleConfig->UseTPM, '1', $tr->tr("yes"));?>
+        </select>
+    </dd>
+    </dl>
+    <blockquote class='inline_help'>
+        <?= $tr->tr("settings.context.tpm"); ?>
+    </blockquote>
 </div>
 
 <dl>
@@ -287,13 +300,15 @@ function showSettingWarning(message, element) {
     const messages = {
         'funnel': "<?= $tr->tr("warnings.funnel"); ?>",
         'subnet': "<?= $tr->tr("warnings.subnet"); ?>",
-        'dns': "<?= $tr->tr("warnings.dns"); ?>"
+        'dns': "<?= $tr->tr("warnings.dns"); ?>",
+        'tpm': "<?= $tr->tr("warnings.tpm"); ?>"
     };
 
     const links = {
         'funnel': "https://docs.unraid.net/unraid-os/manual/security/tailscale/",
         'subnet': "",
-        'dns': ""
+        'dns': "",
+        'tpm': "https://tailscale.com/kb/1596/secure-node-state-storage"
     };
 
     const moreLink = links[message] || "";

--- a/src/usr/local/emhttp/plugins/tailscale/locales/en_US.json
+++ b/src/usr/local/emhttp/plugins/tailscale/locales/en_US.json
@@ -50,7 +50,9 @@
         "funnel": "Allow Tailscale Funnel",
         "hosts": "Add Peers to /etc/hosts",
         "no_logs_no_support": "No Logs No Support",
+        "tpm": "Allow TPM to Encrypt Node Key",
         "context": {
+            "tpm": "Enables the use of a TPM (Trusted Platform Module) for secure storage of the Tailscale node key. This enhances security by protecting the node key from being easily extracted, ensuring that only authorized hardware can access it. Enabling this options requires TPM 2.0. It has no effect if the system does not have a compatible TPM.",
             "unraid_listen": "Configures Unraid services (SSH, WebGUI, SMB, etc.) to listen on Tailscale addresses.",
             "ip_forward": "Sets net.ipv4.ip_forward and net.ipv6.conf.all.forwarding to 1 in sysctl. This change occurs immediately when being enabled.",
             "taildrop": "Specify the path for incoming Taildrop files.",
@@ -108,7 +110,8 @@
         "dns": "Enabling Tailscale MagicDNS on your server can disrupt name resolution inside Docker containers, potentially causing connectivity issues for applications. MagicDNS does not need to be enabled on the server for you to access your Unraid server using MagicDNS names (e.g., 'unraid.tailnet.ts.net') from other devices. Enabling 'Add Peers to /etc/hosts' is a safer alternative that allows Tailscale names to be used on the server.",
         "caution": "Proceed with caution and ensure you understand the implications of this change before continuing.",
         "more_info": "For more information:",
-        "peer_relay_no_acl": "Not configured in Tailnet policy (access controls)."
+        "peer_relay_no_acl": "Not configured in Tailnet policy (access controls).",
+        "tpm": "Enabling the TPM locks the Tailscale node key to the specific hardware of this device. If the TPM is later disabled, the Tailscale node key will become invalid and the device will need to be reauthenticated to Tailscale. It is also possible for TPMs to lock out, which can disrupt Tailscale connectivity and require reauthentication."
     },
     "lock": {
         "sign": "Sign Nodes",

--- a/src/usr/local/emhttp/plugins/tailscale/locales/en_US.json
+++ b/src/usr/local/emhttp/plugins/tailscale/locales/en_US.json
@@ -52,7 +52,7 @@
         "no_logs_no_support": "No Logs No Support",
         "tpm": "Allow TPM to Encrypt Node Key",
         "context": {
-            "tpm": "Enables the use of a TPM (Trusted Platform Module) for secure storage of the Tailscale node key. This enhances security by protecting the node key from being easily extracted, ensuring that only authorized hardware can access it. Enabling this options requires TPM 2.0. It has no effect if the system does not have a compatible TPM.",
+            "tpm": "Enables the use of a TPM (Trusted Platform Module) for secure storage of the Tailscale node key. This enhances security by protecting the node key from being easily extracted, ensuring that only authorized hardware can access it. Enabling this option requires TPM 2.0. It has no effect if the system does not have a compatible TPM.",
             "unraid_listen": "Configures Unraid services (SSH, WebGUI, SMB, etc.) to listen on Tailscale addresses.",
             "ip_forward": "Sets net.ipv4.ip_forward and net.ipv6.conf.all.forwarding to 1 in sysctl. This change occurs immediately when being enabled.",
             "taildrop": "Specify the path for incoming Taildrop files.",

--- a/src/usr/local/emhttp/plugins/tailscale/rc.tailscale
+++ b/src/usr/local/emhttp/plugins/tailscale/rc.tailscale
@@ -11,7 +11,7 @@ fi
 
 start_tailscaled() {
   if ! /usr/bin/pgrep --ns $$ --euid root -f "^/usr/local/sbin/tailscaled" 1> /dev/null 2> /dev/null ; then
-    TAILSCALE_START_CMD="/usr/local/sbin/tailscaled -statedir /boot/config/plugins/tailscale/state -tun tailscale1 -encrypt-state=false -hardware-attestation=false $TAILSCALE_CUSTOM_PARAMS"
+    TAILSCALE_START_CMD="/usr/local/sbin/tailscaled -statedir /boot/config/plugins/tailscale/state -tun tailscale1 $TAILSCALE_CUSTOM_PARAMS"
     log "Starting tailscaled: $TAILSCALE_START_CMD"
     mkdir -p /boot/config/plugins/tailscale/state
     $TAILSCALE_START_CMD 2>&1 | grep -vF "monitor: [unexpected]" >> /var/log/tailscale.log &

--- a/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/Config.php
+++ b/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/Config.php
@@ -31,6 +31,7 @@ class Config
     public bool $AllowFunnel;
     public bool $AddPeersToHosts;
     public bool $NoLogsNoSupport;
+    public bool $UseTPM;
 
     public int $WgPort;
     public string $TaildropDir;
@@ -56,6 +57,7 @@ class Config
         $this->AllowFunnel      = boolval($saved_config["ALLOW_FUNNEL"] ?? "0");
         $this->AddPeersToHosts  = boolval($saved_config["ADD_PEERS_TO_HOSTS"] ?? "0");
         $this->NoLogsNoSupport  = boolval($saved_config["NO_LOGS_NO_SUPPORT"] ?? "0");
+        $this->UseTPM           = boolval($saved_config["USE_TPM"] ?? "0");
 
         $this->WgPort = intval($saved_config["WG_PORT"] ?? "0");
 

--- a/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/System.php
+++ b/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/System.php
@@ -372,6 +372,10 @@ class System extends \EDACerton\PluginUtils\System
             $custom_params .= "-no-logs-no-support ";
         }
 
+        if ( ! $config->UseTPM) {
+            $custom_params .= "-encrypt-state=false -hardware-attestation=false ";
+        }
+
         file_put_contents('/usr/local/emhttp/plugins/tailscale/custom-params.sh', 'TAILSCALE_CUSTOM_PARAMS="' . $custom_params . '"');
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a TPM setting to enable using a Trusted Platform Module to encrypt and bind the Tailscale node key to device hardware (requires TPM 2.0). Disabling TPM after enabling requires reauthentication.

* **User Interface**
  * New TPM control with contextual help and an inline warning shown when toggled.

* **Documentation**
  * Added localized help text and a detailed warning explaining TPM implications and recovery considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->