### PR TITLE
fix: remove embedded link from SMB warning

### DIFF
--- a/src/usr/local/emhttp/plugins/tailscale/locales/en_US.json
+++ b/src/usr/local/emhttp/plugins/tailscale/locales/en_US.json
@@ -103,7 +103,7 @@
     },
     "warnings": {
         "key_expiration": "The Tailscale key will expire in %s days on %s.",
-        "netbios": "NetBIOS is enabled in <a href='/Settings/SMB'>SMB settings</a> - this can prevent shares from being accessed via Tailscale.",
+        "netbios": "NetBIOS is enabled in SMB settings - this can prevent shares from being accessed via Tailscale.",
         "lock": "The tailnet has lock enabled, but this node has not been signed. It will not be able to communicate with the tailnet.",
         "funnel": "Enabling Tailscale Funnel for the Unraid WebGUI exposes your server to the internet, significantly increasing the risk of unauthorized access and potential attacks. This feature should only be enabled if you fully understand the security impact. The recommended/secure approach for remote access is to install Tailscale on the devices you plan to use to access the WebGUI instead of enabling Funnel.",
         "subnet": "Accepting Tailscale subnets on your Unraid server can disrupt local network connectivity in certain network configurations. Accepting routes is not required for your Unraid server to function as a subnet router or exit node. Only enable this option if your Unraid server needs to connect to remote subnets advertised by other devices.",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated netbios warning message to display SMB settings reference as plain text instead of a hyperlink.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->