### PR TITLE
fix: block dependent pages when local api is not ready

### DIFF
--- a/src/usr/local/emhttp/plugins/tailscale/include/Pages/Dashboard.php
+++ b/src/usr/local/emhttp/plugins/tailscale/include/Pages/Dashboard.php
@@ -32,13 +32,18 @@ $tailscaleConfig = $tailscaleConfig ?? new Config();
 $tailscale_dashboard = "<tr><td>" . $tr->tr("tailscale_disabled") . "</td></tr>";
 
 if ($tailscaleConfig->Enable) {
-    $tailscaleInfo     = $tailscaleInfo ?? new Info($tr);
-    $tailscaleDashInfo = $tailscaleInfo->getDashboardInfo();
+    $localAPI = $localAPI ?? new LocalAPI();
+    if ( ! $localAPI->isReady()) {
+        $tailscale_dashboard = "<tr><td>" . $tr->tr("warnings.not_ready") . "</td></tr>";
+    } else {
+        $tailscaleInfo     = $tailscaleInfo ?? new Info($tr);
+        $tailscaleDashInfo = $tailscaleInfo->getDashboardInfo();
 
-    $tailscale_dashboard = Utils::printDash($tr->tr("info.online"), $tailscaleDashInfo->Online);
-    $tailscale_dashboard .= Utils::printDash($tr->tr("info.hostname"), $tailscaleDashInfo->HostName);
-    $tailscale_dashboard .= Utils::printDash($tr->tr("info.dns"), $tailscaleDashInfo->DNSName);
-    $tailscale_dashboard .= Utils::printDash($tr->tr("info.ip"), implode("<br><span class='w26'>&nbsp;</span>", $tailscaleDashInfo->TailscaleIPs));
+        $tailscale_dashboard = Utils::printDash($tr->tr("info.online"), $tailscaleDashInfo->Online);
+        $tailscale_dashboard .= Utils::printDash($tr->tr("info.hostname"), $tailscaleDashInfo->HostName);
+        $tailscale_dashboard .= Utils::printDash($tr->tr("info.dns"), $tailscaleDashInfo->DNSName);
+        $tailscale_dashboard .= Utils::printDash($tr->tr("info.ip"), implode("<br><span class='w26'>&nbsp;</span>", $tailscaleDashInfo->TailscaleIPs));
+    }
 }
 
 echo <<<EOT

--- a/src/usr/local/emhttp/plugins/tailscale/include/Pages/Info.php
+++ b/src/usr/local/emhttp/plugins/tailscale/include/Pages/Info.php
@@ -27,10 +27,7 @@ if ( ! defined(__NAMESPACE__ . '\PLUGIN_ROOT') || ! defined(__NAMESPACE__ . '\PL
 
 $tr = $tr ?? new Translator(PLUGIN_ROOT);
 
-$tailscaleConfig = $tailscaleConfig ?? new Config();
-
-if ( ! $tailscaleConfig->Enable) {
-    echo($tr->tr("tailscale_disabled"));
+if ( ! Utils::pageChecks($tr)) {
     return;
 }
 

--- a/src/usr/local/emhttp/plugins/tailscale/include/Pages/Lock.php
+++ b/src/usr/local/emhttp/plugins/tailscale/include/Pages/Lock.php
@@ -27,15 +27,8 @@ if ( ! defined(__NAMESPACE__ . '\PLUGIN_ROOT') || ! defined(__NAMESPACE__ . '\PL
 
 $tr = $tr ?? new Translator(PLUGIN_ROOT);
 
-$tailscaleConfig = $tailscaleConfig ?? new Config();
-
-if ( ! $tailscaleConfig->Enable) {
-    echo($tr->tr("tailscale_disabled"));
+if ( ! Utils::pageChecks($tr)) {
     return;
-}
-
-if ( ! defined(__NAMESPACE__ . "\PLUGIN_ROOT")) {
-    throw new \RuntimeException("PLUGIN_ROOT not defined");
 }
 
 $signingNode = false;

--- a/src/usr/local/emhttp/plugins/tailscale/include/Pages/Status.php
+++ b/src/usr/local/emhttp/plugins/tailscale/include/Pages/Status.php
@@ -27,10 +27,7 @@ if ( ! defined(__NAMESPACE__ . '\PLUGIN_ROOT') || ! defined(__NAMESPACE__ . '\PL
 
 $tr = $tr ?? new Translator(PLUGIN_ROOT);
 
-$tailscaleConfig = $tailscaleConfig ?? new Config();
-
-if ( ! $tailscaleConfig->Enable) {
-    echo($tr->tr("tailscale_disabled"));
+if ( ! Utils::pageChecks($tr)) {
     return;
 }
 ?>

--- a/src/usr/local/emhttp/plugins/tailscale/include/Pages/Tailscale.php
+++ b/src/usr/local/emhttp/plugins/tailscale/include/Pages/Tailscale.php
@@ -30,10 +30,7 @@ if ( ! defined(__NAMESPACE__ . '\PLUGIN_ROOT') || ! defined(__NAMESPACE__ . '\PL
 
 $tr = $tr ?? new Translator(PLUGIN_ROOT);
 
-$tailscaleConfig = $tailscaleConfig ?? new Config();
-
-if ( ! $tailscaleConfig->Enable) {
-    echo($tr->tr("tailscale_disabled"));
+if ( ! Utils::pageChecks($tr)) {
     return;
 }
 

--- a/src/usr/local/emhttp/plugins/tailscale/locales/en_US.json
+++ b/src/usr/local/emhttp/plugins/tailscale/locales/en_US.json
@@ -102,6 +102,7 @@
         }
     },
     "warnings": {
+        "not_ready": "Tailscale is not yet ready. Please wait a moment and refresh the page.",
         "key_expiration": "The Tailscale key will expire in %s days on %s.",
         "netbios": "NetBIOS is enabled in SMB settings - this can prevent shares from being accessed via Tailscale.",
         "lock": "The tailnet has lock enabled, but this node has not been signed. It will not be able to communicate with the tailnet.",

--- a/src/usr/local/emhttp/plugins/tailscale/locales/en_US.json
+++ b/src/usr/local/emhttp/plugins/tailscale/locales/en_US.json
@@ -102,7 +102,7 @@
         }
     },
     "warnings": {
-        "not_ready": "Tailscale is not yet ready. Please wait a moment and refresh the page.",
+        "not_ready": "Tailscale is not yet ready.",
         "key_expiration": "The Tailscale key will expire in %s days on %s.",
         "netbios": "NetBIOS is enabled in SMB settings - this can prevent shares from being accessed via Tailscale.",
         "lock": "The tailnet has lock enabled, but this node has not been signed. It will not be able to communicate with the tailnet.",

--- a/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/LocalAPI.php
+++ b/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/LocalAPI.php
@@ -102,6 +102,26 @@ class LocalAPI
         return (object) $decoded;
     }
 
+    public function isReady(): bool
+    {
+        // Check if tailscaleSocket exists
+        if ( ! file_exists($this::tailscaleSocket)) {
+            return false;
+        }
+
+        // Check backend state from status endpoint
+        try {
+            $status = $this->decodeJSONResponse($this->tailscaleLocalAPI('v0/status'));
+            if (isset($status->BackendState) && $status->BackendState === 'Running') {
+                return true;
+            }
+        } catch (\RuntimeException $e) {
+            // No need to log here, as this is just a readiness check
+        }
+
+        return false;
+    }
+
     public function getStatus(): \stdClass
     {
         try {

--- a/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/LocalAPI.php
+++ b/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/LocalAPI.php
@@ -111,8 +111,9 @@ class LocalAPI
 
         // Check backend state from status endpoint
         try {
-            $status = $this->decodeJSONResponse($this->tailscaleLocalAPI('v0/status'));
-            if (isset($status->BackendState) && $status->BackendState === 'Running') {
+            $acceptedStates = ['Running', 'NeedsLogin', 'NeedsMachineAuth'];
+            $status         = $this->decodeJSONResponse($this->tailscaleLocalAPI('v0/status'));
+            if (isset($status->BackendState) && in_array($status->BackendState, $acceptedStates, true)) {
                 return true;
             }
         } catch (\RuntimeException $e) {

--- a/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/LocalAPI.php
+++ b/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/LocalAPI.php
@@ -111,7 +111,7 @@ class LocalAPI
 
         // Check backend state from status endpoint
         try {
-            $acceptedStates = ['Running', 'NeedsLogin', 'NeedsMachineAuth'];
+            $acceptedStates = ['Running', 'NeedsLogin', 'NeedsMachineAuth', 'Stopped'];
             $status         = $this->decodeJSONResponse($this->tailscaleLocalAPI('v0/status'));
             if (isset($status->BackendState) && in_array($status->BackendState, $acceptedStates, true)) {
                 return true;

--- a/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/Utils.php
+++ b/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/Utils.php
@@ -20,6 +20,7 @@
 namespace Tailscale;
 
 use PhpIP\IPBlock;
+use EDACerton\PluginUtils\Translator;
 
 class Utils extends \EDACerton\PluginUtils\Utils
 {
@@ -163,5 +164,20 @@ class Utils extends \EDACerton\PluginUtils\Utils
         }
 
         return array_unique($ports);
+    }
+
+    public static function pageChecks(Translator $tr): bool
+    {
+        if ( ! (new Config())->Enable) {
+            echo($tr->tr("tailscale_disabled"));
+            return false;
+        }
+
+        if ( ! (new LocalAPI())->isReady()) {
+            echo($tr->tr("warnings.not_ready"));
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/Utils.php
+++ b/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/Utils.php
@@ -168,13 +168,33 @@ class Utils extends \EDACerton\PluginUtils\Utils
 
     public static function pageChecks(Translator $tr): bool
     {
-        if ( ! (new Config())->Enable) {
+        static $config   = null;
+        static $localAPI = null;
+
+        if ($config === null) {
+            $config = new Config();
+        }
+        if ($localAPI === null) {
+            $localAPI = new LocalAPI();
+        }
+
+        if ( ! $config->Enable) {
             echo($tr->tr("tailscale_disabled"));
             return false;
         }
 
-        if ( ! (new LocalAPI())->isReady()) {
+        if ( ! $localAPI->isReady()) {
             echo($tr->tr("warnings.not_ready"));
+            echo(<<<EOT
+                <script>
+                    $(function() {
+                        setTimeout(function() {
+                            window.location = window.location.href;
+                        }, 5000);
+                    });
+                </script>
+                EOT
+            );
             return false;
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pages now display a "Tailscale is not yet ready." warning while the service initializes.

* **Bug Fixes**
  * Dashboard and other Tailscale pages perform a centralized readiness check before showing data to prevent incomplete or missing information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->