### PR TITLE
fix: old references in erase script

### DIFF
--- a/src/usr/local/emhttp/plugins/tailscale/erase.sh
+++ b/src/usr/local/emhttp/plugins/tailscale/erase.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-. /usr/local/emhttp/plugins/tailscale/log.sh
+. /usr/local/php/unraid-tailscale-utils/log.sh
 
 log "Stopping Tailscale"
 /etc/rc.d/rc.tailscale stop
@@ -10,4 +10,6 @@ rm -f /boot/config/plugins/tailscale/tailscale.cfg
 rm -rf  /boot/config/plugins/tailscale/state/
 
 log "Restarting Tailscale"
-echo "sleep 5 ; /usr/local/emhttp/plugins/tailscale/update-settings.sh" | at now 2>/dev/null
+/etc/rc.d/rc.tailscale start
+
+sleep 10


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Tailscale erase/reset flow so the service restarts more reliably after clearing configuration.
  * Made the post-erase wait behavior more consistent, helping settings updates complete more predictably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->