### PR TITLE
feat: restart tailscaled if it terminates or becomes unresponsive

### DIFF
--- a/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/System.php
+++ b/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/System.php
@@ -130,10 +130,9 @@ class System extends \EDACerton\PluginUtils\System
 
         // Check if tailscaled is responsive via the local API. If it is not responsive, we will restart it.
         $localAPI = new LocalAPI();
-        try {
-            $status = $localAPI->getStatus();
-        } catch (\RuntimeException $e) {
-            Utils::logwrap("tailscaled is running but not responsive: " . $e->getMessage());
+        $status   = $localAPI->getStatus();
+        if (empty((array) $status)) {
+            Utils::logwrap("tailscaled is running but not responsive.");
             return false;
         }
         return true;

--- a/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/System.php
+++ b/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/System.php
@@ -116,6 +116,43 @@ class System extends \EDACerton\PluginUtils\System
         return false;
     }
 
+    public static function isTailscaleRunning(): bool
+    {
+        // Objective: check if tailscaled is running, and if not, start it. If it is running, check if it is responsive, and if not, restart it.
+        // tailscaled might be running in containers too, which we don't care about, so when we check for the process, we will check for the one that is running in the host namespace.
+
+        // This will return the PID of the tailscaled process if it is running, or an empty string if it is not.
+        $tailscaled_pid = Utils::runwrap('/usr/bin/pgrep --ns $$ --euid root -f "^/usr/local/sbin/tailscaled"', false, false);
+        if (empty($tailscaled_pid)) {
+            Utils::logwrap("tailscaled is not running.");
+            return false;
+        }
+
+        // Check if tailscaled is responsive via the local API. If it is not responsive, we will restart it.
+        $localAPI = new LocalAPI();
+        try {
+            $status = $localAPI->getStatus();
+        } catch (\RuntimeException $e) {
+            Utils::logwrap("tailscaled is running but not responsive: " . $e->getMessage());
+            return false;
+        }
+        return true;
+    }
+
+    public static function checkTailscale(): void
+    {
+        if ( ! self::isTailscaleRunning()) {
+            // Pause and check again to avoid false positives (e.g., during startup/heavy load)
+            sleep(30);
+
+            // This causes a false positive with phpstan because it doesn't know that the process could have started in the meantime
+            // @phpstan-ignore booleanNot.alwaysTrue
+            if ( ! self::isTailscaleRunning()) {
+                Utils::runwrap("/etc/rc.d/rc.tailscale restart");
+            }
+        }
+    }
+
     public static function checkServeConfig(Config $config): void
     {
         $ident_config = parse_ini_file("/boot/config/ident.cfg") ?: array();

--- a/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/Watcher.php
+++ b/src/usr/local/php/unraid-tailscale-utils/unraid-tailscale-utils/Watcher.php
@@ -65,6 +65,8 @@ class Watcher
                 }
             }
 
+            $utils->run_task('Tailscale\System::checkTailscale');
+
             if (isset($tailscale_ipv4)) {
                 if ($need_ip) {
                     $utils->logmsg("Tailscale IP detected, applying configuration");


### PR DESCRIPTION
Closes #111 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic monitoring to detect when the Tailscale service is unavailable or unresponsive.
  * Added automatic recovery that retries after a brief delay and restarts Tailscale when needed.
  * Integrated health checks into the background monitoring process to improve service reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->